### PR TITLE
Add github action for running jest tests

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -5,12 +5,14 @@ on:
       - '__tests__/**'
       - 'components/**'
       - '.github/workflows/jest.yml'
+      - 'jest.config.ts'
     branches: [ main ]
   pull_request:
     paths:
       - '__tests__/**'
       - 'components/**'
       - '.github/workflows/jest.yml'
+      - 'jest.config.ts'
     branches: [ main ]
 jobs:
   test:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,43 @@
+name: Jest
+on:
+  push:
+    paths:
+      - '__tests__/**'
+      - 'components/**'
+    branches: [ main ]
+  pull_request:
+    paths:
+      - '__tests__/**'
+      - 'components/**'
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+
+      # Speed up subsequent runs with caching
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      # Install required deps for action
+      - name: Install Dependencies
+        run: npm install
+
+      # Finally, run our tests
+      - name: Run the tests
+        run: npm test

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -4,11 +4,13 @@ on:
     paths:
       - '__tests__/**'
       - 'components/**'
+      - '.github/workflows/jest.yml'
     branches: [ main ]
   pull_request:
     paths:
       - '__tests__/**'
       - 'components/**'
+      - '.github/workflows/jest.yml'
     branches: [ main ]
 jobs:
   test:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -18,11 +18,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "12"
+          node-version: lts/*
 
       # Speed up subsequent runs with caching
       - name: Cache node modules

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -22,25 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-
-      # Speed up subsequent runs with caching
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      # Install required deps for action
       - name: Install Dependencies
         run: npm install
-
-      # Finally, run our tests
       - name: Run the tests
         run: npm test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
   clearMocks: true,
+  roots: ['<rootDir>/__tests__/'],
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }


### PR DESCRIPTION
This action runs on pushes to the `main` branch and pull requests to the `main` branch but only when there are changes made to the `__tests__` folder and `components` folder. Since the unit tests written with jest only test components, then changes elsewhere (ex. `pages`) don't need to pass the jest tests. In addition, if tests are back-filled on existing components, those changes should trigger this GitHub action to run. Currently, the production environment and the host machine running the tests in CI are not so similar, so that will need addressing, probably via containerisation. Also, in the future, if the GitHub action runner is considered too slow, steps containing logic on caching can be included.